### PR TITLE
Add Linux AArch64 wheel build support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
-version: 2
+version: 2.1
 
 # NOTE: We run these in CircleCI because it has better artifacts support
 # and it is possible to publish image diffs as HTML like pytest-mpl in the future.
+
 jobs:
 
   image-tests-mpl311:
@@ -36,9 +37,68 @@ jobs:
       - store_artifacts:
           path: results
 
+  manylinux2014-aarch64:
+    parameters:
+      production_wheel:
+        type: boolean
+        default: false
+
+    machine:
+      image: ubuntu-2004:202101-01
+    resource_class: arm.medium
+    environment:
+      CIBW_BEFORE_TEST: pytest -p no:warnings --astropy-header -m "not hypothesis" -k "not test_data_out_of_range and not test_wcsapi_extension" --pyargs astropy
+      CIBW_TEST_EXTRAS: test
+      CIBW_BUILD_VERBOSITY_LINUX: 3
+      CIBW_BUILD: "cp38-* cp39-* cp310-*"
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: |
+            python3 -m pip install --upgrade pip==21.2.4
+            python3 -m pip install cibuildwheel==2.1.2 twine
+      - run:
+          name: cibuildwheel
+          command: |
+            python3 -m cibuildwheel --output-dir wheelhouse
+      - store_artifacts:
+          path: ./wheelhouse
+          destination: astropy
+      - when:
+          condition:  << parameters.production_wheel>>
+          name: upload wheels to pypi
+          steps:
+            - run: twine upload --skip-existing -u TWINE_USERNAME  -p TWINE_PASSWORD wheelhouse/*
+
 workflows:
-  version: 2
+  version: 2.1
   tests:
     jobs:
       - image-tests-mpl311
       - image-tests-mpldev
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - manylinux2014-aarch64:
+          name: nightly-wheel-AArch64
+  build:
+    jobs:
+      - manylinux2014-aarch64:
+          name: development-wheel-AArch64
+      - manylinux2014-aarch64:
+          name: production-wheel-AArch64
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+          matrix:
+            parameters:
+              production_wheel: [true]


### PR DESCRIPTION
Owner: Madhukar
Fix: Linux AArch64 wheel build support
Build Logs: 
https://app.circleci.com/pipelines/github/odidev/astropy/48/workflows/15c2c0b1-edfe-4519-a3c2-101a26eb860f
https://app.circleci.com/pipelines/github/odidev/astropy/47/workflows/b6cfb6ef-9c1d-4d2f-bf6b-13325951eb71
https://app.circleci.com/pipelines/github/odidev/astropy/47/workflows/8a8b9571-6b43-4af9-b3c4-ab729df2f376

Reviewer: Pruthvi and Disha

**Note:** One build log is for pushing a tag and others are for commit or pull request. 
